### PR TITLE
fix: parse without glob

### DIFF
--- a/src/nc.rs
+++ b/src/nc.rs
@@ -114,7 +114,7 @@ fn parse_files(files: Vec<PathBuf>) -> Result<Config> {
 }
 
 pub fn parse(path: impl AsRef<Path>) -> Result<Config> {
-    parse_files(glob_config_files(path))
+    parse_files(vec![path.as_ref().into()])
 }
 
 pub fn parse_glob(path: impl AsRef<Path>) -> Result<Config> {


### PR DESCRIPTION
Hello!

I think that  fn `parse` should parse only specified file unlike fn `parse_glob`.

Related: https://github.com/nextcloud/notify_push/issues/108